### PR TITLE
Make deployable to cloud.gov

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@ _site/
 .sass-cache/
 .jekyll-metadata
 .DS_Store
-data.json
+Staticfile.auth

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ _site/
 .sass-cache/
 .jekyll-metadata
 .DS_Store
+data.json

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
 source "https://rubygems.org"
 
+gem 'jekyll'
 gem 'uswds-jekyll', :git => 'https://github.com/18F/uswds-jekyll.git'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -48,7 +48,8 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  jekyll
   uswds-jekyll!
 
 BUNDLED WITH
-   1.13.6
+   1.14.6

--- a/Staticfile
+++ b/Staticfile
@@ -1,0 +1,1 @@
+root: _site

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,0 +1,8 @@
+---
+applications:
+- name: 18f-capacity-planning
+  memory: 64M
+  buildpack: https://github.com/cloudfoundry/staticfile-buildpack.git
+  env:
+    FORCE_HTTPS: true
+


### PR DESCRIPTION
This adds the necessary components for cloud.gov to deploy the `_site` folder. Note that since we're not on CI, we need to run `jekyll build` before we `cf push`. 