### PR TITLE
[WIP]Add tabs for years

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -4,7 +4,10 @@ theme: uswds-jekyll
 
 styles:
   - /assets/uswds/css/uswds.min.css
+  - /assets/css/main.css
 
 scripts:
   - src: /assets/uswds/js/uswds.min.js
+    async: true
+  - src: /assets/js/main.js
     async: true

--- a/_layouts/landing.html
+++ b/_layouts/landing.html
@@ -9,3 +9,35 @@ layout: base
     </div>
   </div>
 </section>
+<script>
+/*!
+  * domready (c) Dustin Diaz 2014 - License MIT
+  */
+!function (name, definition) {
+
+  if (typeof module != 'undefined') module.exports = definition()
+  else if (typeof define == 'function' && typeof define.amd == 'object') define(definition)
+  else this[name] = definition()
+
+}('domready', function () {
+
+  var fns = [], listener
+    , doc = document
+    , hack = doc.documentElement.doScroll
+    , domContentLoaded = 'DOMContentLoaded'
+    , loaded = (hack ? /^loaded|^c/ : /^loaded|^i|^c/).test(doc.readyState)
+
+
+  if (!loaded)
+  doc.addEventListener(domContentLoaded, listener = function () {
+    doc.removeEventListener(domContentLoaded, listener)
+    loaded = 1
+    while (listener = fns.shift()) listener()
+  })
+
+  return function (fn) {
+    loaded ? setTimeout(fn, 0) : fns.push(fn)
+  }
+
+});
+</script>

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1,15 +1,20 @@
 ---
 ---
 /* explicitly hide the tab panel content so all of them show if JS isn't enabled */
-.tabs__content.hidden {
+.hidden {
   display: none;
 }
 
 .tabs__tab {
   margin: 0;
-  padding: 0 1.1rem 0 1rem;
+  padding: 0 1.1rem 0.5rem 1rem;
   border-right: 1px solid #5b616b;
   text-align: left;
+  font-size: 2rem;
+}
+
+.tabs__tab:first-child {
+  padding-left: 0;
 }
 
 .tabs__tab:last-child {

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1,0 +1,6 @@
+---
+---
+/* explicitly hide the tab panel content so all of them show if JS isn't enabled */
+.tabs__content.hidden {
+  display: none;
+}

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -4,3 +4,27 @@
 .tabs__content.hidden {
   display: none;
 }
+
+.tabs__tab {
+  margin: 0;
+  padding: 0 1.1rem 0 1rem;
+  border-right: 1px solid #5b616b;
+  text-align: left;
+}
+
+.tabs__tab:last-child {
+  border-right: none;
+}
+
+.tabs__tab.active {
+  font-weight: 700;
+}
+
+a.tabs__tab:visited {
+  color: #0071bc;
+}
+
+a.tabs__tab:visited:hover,
+a.tabs__tab:visited:active {
+  color: #205493;
+}

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -15,8 +15,6 @@ function initTabs(){
 
 function initTabContent(){
   var contentPanels = document.getElementsByClassName("tabs__content");
-  //hide h2
-  contentPanels[0].children.item('h2').classList.add('hidden');
   // skip the first panel so it shows by default -- elem 0 is a text node
   // TODO: let's implement URL hashes and make this show the correct hash
   for (var i=1; i<contentPanels.length; i++) {
@@ -52,8 +50,6 @@ function showActivePanel(href) {
     }
   };
   currentPanel.classList.remove("hidden");
-  // hide the h2 so the nav functions as a label instead
-  currentPanel.children.item('h2').classList.add('hidden');
 }
 
 initTabs();

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -2,6 +2,11 @@ function initTabs(){
   var tabs = document.getElementsByClassName("tabs__tab");
   for (var i=0; i<tabs.length; i++) {
     var tab = tabs[i];
+    // add the active class to the first tab by default
+    // TODO: let's implement URL hashes and make this show the correct hash
+    if (i == 0) {
+      tab.classList.add("active");
+    }
     tab.addEventListener('click', function(e) {
       showActiveTab(e, this);
     }, false);
@@ -10,7 +15,7 @@ function initTabs(){
 
 function initTabContent(){
   var contentPanels = document.getElementsByClassName("tabs__content");
-  // skip the first panel so it shows by default
+  // skip the first panel so it shows by default -- elem 0 is a text node
   // TODO: let's implement URL hashes and make this show the correct hash
   for (var i=1; i<contentPanels.length; i++) {
     contentPanels[i].classList.add("hidden");

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -52,5 +52,7 @@ function showActivePanel(href) {
   currentPanel.classList.remove("hidden");
 }
 
-initTabs();
-initTabContent();
+domready(function(){
+  initTabs();
+  initTabContent();
+});

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -15,6 +15,8 @@ function initTabs(){
 
 function initTabContent(){
   var contentPanels = document.getElementsByClassName("tabs__content");
+  //hide h2
+  contentPanels[0].children.item('h2').classList.add('hidden');
   // skip the first panel so it shows by default -- elem 0 is a text node
   // TODO: let's implement URL hashes and make this show the correct hash
   for (var i=1; i<contentPanels.length; i++) {
@@ -50,6 +52,8 @@ function showActivePanel(href) {
     }
   };
   currentPanel.classList.remove("hidden");
+  // hide the h2 so the nav functions as a label instead
+  currentPanel.children.item('h2').classList.add('hidden');
 }
 
 initTabs();

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,0 +1,51 @@
+function initTabs(){
+  var tabs = document.getElementsByClassName("tabs__tab");
+  for (var i=0; i<tabs.length; i++) {
+    var tab = tabs[i];
+    tab.addEventListener('click', function(e) {
+      showActiveTab(e, this);
+    }, false);
+  };
+};
+
+function initTabContent(){
+  var contentPanels = document.getElementsByClassName("tabs__content");
+  // skip the first panel so it shows by default
+  // TODO: let's implement URL hashes and make this show the correct hash
+  for (var i=1; i<contentPanels.length; i++) {
+    contentPanels[i].classList.add("hidden");
+  };
+};
+
+function showActiveTab(e, tab) {
+  e.preventDefault();
+
+  var nodes = tab.parentNode.children;
+  for (var i in nodes){
+    var node = nodes[i];
+    // if it's not a text node and not the current node and has the active class
+    if(node.nodeType === 1 && node != tab && node.classList.contains("active")){
+      node.classList.remove("active");
+    }
+  };
+
+  tab.classList.add("active");
+  showActivePanel(tab.getAttribute('href'));
+};
+
+function showActivePanel(href) {
+  // remove the pound sign from the front of the ID
+  var currentPanel = document.getElementById(href.slice(1));
+  var nodes = document.getElementsByClassName("tabs__content");
+  for (var i in nodes){
+    var node = nodes[i];
+    // explicitly hide the panels with JS so all of them show if JS isn't active
+    if(node.nodeType === 1 && node != currentPanel){
+      node.classList.add("hidden");
+    }
+  };
+  currentPanel.classList.remove("hidden");
+}
+
+initTabs();
+initTabContent();

--- a/pages/1-1-hiring-needs.html
+++ b/pages/1-1-hiring-needs.html
@@ -40,13 +40,15 @@ layout: landing
 {% assign years = term2 | group_by_exp: 'teammate', 'teammate.term_end_date | slice: 0,4' | sort: 'name' %}
 
 <h2>Select calendar year</h2>
+<div class="tabs__wrapper">
 {% for year in years %}
-  <a href="#{{ year.name }}">{{ year.name }}</a>
+  <a id="tab-{{ year.name }}" class="tabs__tab" href="#{{ year.name }}">{{ year.name }}</a>
 {% endfor %}
+</div>
 
 {% for year in years %}
   {% assign months = year.items | group_by_exp: 'teammate', 'teammate.term_end_date | slice: 5,2' | sort: 'name' %}
-<section id="{{ year.name }}">
+<section id="{{ year.name }}" class="tabs__content">
   <h2 id="{{ year.name }}">{{ year.name }}</h2>
   <table>
     <thead>

--- a/pages/1st-term-ending.html
+++ b/pages/1st-term-ending.html
@@ -12,16 +12,14 @@ layout: landing
 
 <h1>{{ page.title }}</h1>
 <h2>Select calendar year</h2>
+<div class="tabs__wrapper">
 {% for year in years %}
-  <a href="#{{ year.name }}">{{ year.name }}</a>
+  <a id="tab-{{ year.name }}" class="tabs__tab" href="#{{ year.name }}">{{ year.name }}</a>
 {% endfor %}
-
+</div>
 {% for year in years %}
   {% assign months = year.items | group_by_exp: 'teammate', 'teammate.term_end_date | slice: 5,2' | sort: 'name' %}
-<section id="{{ year.name }}" class="tabs">
-  <input type="radio" id="tab-{{ year.name }}" name="tab-group-{{ year.name }}" checked>
-  <label class="tabs__tab" for="tab-{{ year.name }}">{{ year.name }}</label>
-  <div class="tabs__content">
+  <section id="{{ year.name }}" class="tabs__content">
     <h2 id="{{ year.name }}">{{ year.name }}</h2>
     <table>
       <thead>
@@ -101,6 +99,5 @@ layout: landing
       </tbody>
     </table>
     {% endfor %}
-  </div>
-</section>
+  </section>
 {% endfor %}

--- a/pages/1st-term-ending.html
+++ b/pages/1st-term-ending.html
@@ -18,85 +18,89 @@ layout: landing
 
 {% for year in years %}
   {% assign months = year.items | group_by_exp: 'teammate', 'teammate.term_end_date | slice: 5,2' | sort: 'name' %}
-<section id="{{ year.name }}">
-  <h2 id="{{ year.name }}">{{ year.name }}</h2>
-  <table>
-    <thead>
-      <tr>
-        {% for month in monthnames %}
-          <th scope="col">{{ month }}</th>
-        {% endfor %}
-        <th scope="col">Total</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        {% assign yearly_total = 0 %}
-        {% for month in monthnames %}
-          {% assign pattern = year.name | append: '-' | append: monthvals[forloop.index0] %}
-          {% assign where = 'teammate.term_end_date contains "%"' | replace: '%', pattern %}
-          {% assign items = year.items | where_exp: 'teammate', where %}
-          <td>{{ items.size }}</td>
-          {% assign yearly_total = yearly_total | plus: items.size %}
-        {% endfor %}
-        <td>{{ yearly_total }}</td>
-      </tr>
-    </tbody>
-  </table>
+<section id="{{ year.name }}" class="tabs">
+  <input type="radio" id="tab-{{ year.name }}" name="tab-group-{{ year.name }}" checked>
+  <label class="tabs__tab" for="tab-{{ year.name }}">{{ year.name }}</label>
+  <div class="tabs__content">
+    <h2 id="{{ year.name }}">{{ year.name }}</h2>
+    <table>
+      <thead>
+        <tr>
+          {% for month in monthnames %}
+            <th scope="col">{{ month }}</th>
+          {% endfor %}
+          <th scope="col">Total</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          {% assign yearly_total = 0 %}
+          {% for month in monthnames %}
+            {% assign pattern = year.name | append: '-' | append: monthvals[forloop.index0] %}
+            {% assign where = 'teammate.term_end_date contains "%"' | replace: '%', pattern %}
+            {% assign items = year.items | where_exp: 'teammate', where %}
+            <td>{{ items.size }}</td>
+            {% assign yearly_total = yearly_total | plus: items.size %}
+          {% endfor %}
+          <td>{{ yearly_total }}</td>
+        </tr>
+      </tbody>
+    </table>
 
-  {% for group in months %}
-    {% if group.name == '01' %}
-      {% assign month = 'January' %}
-    {% elsif group.name == '02' %}
-      {% assign month = 'February' %}
-    {% elsif group.name == '03' %}
-      {% assign month = 'March' %}
-    {% elsif group.name == '04' %}
-      {% assign month = 'April' %}
-    {% elsif group.name == '05' %}
-      {% assign month = 'May' %}
-    {% elsif group.name == '06' %}
-      {% assign month = 'June' %}
-    {% elsif group.name == '07' %}
-      {% assign month = 'July' %}
-    {% elsif group.name == '08' %}
-      {% assign month = 'August' %}
-    {% elsif group.name == '09' %}
-      {% assign month = 'September' %}
-    {% elsif group.name == '10' %}
-      {% assign month = 'October' %}
-    {% elsif group.name == '11' %}
-      {% assign month = 'November' %}
-    {% elsif group.name == '12' %}
-      {% assign month = 'December' %}
-    {% endif %}
+    {% for group in months %}
+      {% if group.name == '01' %}
+        {% assign month = 'January' %}
+      {% elsif group.name == '02' %}
+        {% assign month = 'February' %}
+      {% elsif group.name == '03' %}
+        {% assign month = 'March' %}
+      {% elsif group.name == '04' %}
+        {% assign month = 'April' %}
+      {% elsif group.name == '05' %}
+        {% assign month = 'May' %}
+      {% elsif group.name == '06' %}
+        {% assign month = 'June' %}
+      {% elsif group.name == '07' %}
+        {% assign month = 'July' %}
+      {% elsif group.name == '08' %}
+        {% assign month = 'August' %}
+      {% elsif group.name == '09' %}
+        {% assign month = 'September' %}
+      {% elsif group.name == '10' %}
+        {% assign month = 'October' %}
+      {% elsif group.name == '11' %}
+        {% assign month = 'November' %}
+      {% elsif group.name == '12' %}
+        {% assign month = 'December' %}
+      {% endif %}
 
-  <h3>{{ month }} {{ year.name }} - {{ group.size }} Billable Employees Ending 1st Term</h3>
-  <table>
-    <thead>
-      <tr>
-        <th scope="col">#</th>
-        <th scope="col">Name</th>
-        <th scope="col">Chapter</th>
-        <th scope="col">Role</th>
-        <th scope="col">Billable status</th>
-        <th scope="col">End of term date</th>
-      </tr>
-    </thead>
-    <tbody>
-      {% for teammate in group.items %}
-      {% assign names = teammate.email | remove: '@gsa.gov' | split: '.' %}
-      <tr>
-        <th scope="row">{{ forloop.index }}</th>
-        <td>{% for name in names %}{{ name | capitalize }} {% endfor %}</td>
-        <td>{{ teammate.team }}</td>
-        <td>{{ teammate.role }}</td>
-        <td>{{ teammate.billable_status }}</td>
-        <td>{{ teammate.term_end_date | date: "%b %d, %Y"}}</td>
-      </tr>
-      {% endfor %}
-    </tbody>
-  </table>
-  {% endfor %}
+    <h3>{{ month }} {{ year.name }} - {{ group.size }} Billable Employees Ending 1st Term</h3>
+    <table>
+      <thead>
+        <tr>
+          <th scope="col">#</th>
+          <th scope="col">Name</th>
+          <th scope="col">Chapter</th>
+          <th scope="col">Role</th>
+          <th scope="col">Billable status</th>
+          <th scope="col">End of term date</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for teammate in group.items %}
+        {% assign names = teammate.email | remove: '@gsa.gov' | split: '.' %}
+        <tr>
+          <th scope="row">{{ forloop.index }}</th>
+          <td>{% for name in names %}{{ name | capitalize }} {% endfor %}</td>
+          <td>{{ teammate.team }}</td>
+          <td>{{ teammate.role }}</td>
+          <td>{{ teammate.billable_status }}</td>
+          <td>{{ teammate.term_end_date | date: "%b %d, %Y"}}</td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+    {% endfor %}
+  </div>
 </section>
 {% endfor %}

--- a/pages/2nd-term-ending.html
+++ b/pages/2nd-term-ending.html
@@ -13,13 +13,15 @@ layout: landing
 
 <h1>{{ page.title }}</h1>
 <h2>Select calendar year</h2>
+<div class="tabs__wrapper">
 {% for year in years %}
-  <a href="#{{ year.name }}">{{ year.name }}</a>
+  <a id="tab-{{ year.name }}" class="tabs__tab" href="#{{ year.name }}">{{ year.name }}</a>
 {% endfor %}
+</div>
 
 {% for year in years %}
   {% assign months = year.items | group_by_exp: 'teammate', 'teammate.term_end_date | slice: 5,2' | sort: 'name' %}
-<section id="{{ year.name }}">
+<section id="{{ year.name }}" class="tabs__content">
   <h2 id="{{ year.name }}">{{ year.name }}</h2>
   <table>
     <thead>

--- a/pages/predictive-hiring-needs.html
+++ b/pages/predictive-hiring-needs.html
@@ -44,13 +44,15 @@ layout: landing
 {% assign years = term2 | group_by_exp: 'teammate', 'teammate.term_end_date | slice: 0,4' | sort: 'name' %}
 
 <h2>Select calendar year</h2>
+<div class="tabs__wrapper">
 {% for year in years %}
-  <a href="#{{ year.name }}">{{ year.name }}</a>
+  <a id="tab-{{ year.name }}" class="tabs__tab" href="#{{ year.name }}">{{ year.name }}</a>
 {% endfor %}
+</div>
 
 {% for year in years %}
   {% assign months = year.items | group_by_exp: 'teammate', 'teammate.term_end_date | slice: 5,2' | sort: 'name' %}
-<section id="{{ year.name }}">
+<section id="{{ year.name }}" class="tabs__content">
   <h2 id="{{ year.name }}">{{ year.name }}</h2>
   <table>
     <thead>


### PR DESCRIPTION
This adds custom CSS and JS builds to the Jekyll config so that we can have tabs for years. It's currently unstyled and looks like this (with year 2019 selected):
<img width="673" alt="screen shot 2017-05-15 at 12 28 47 pm" src="https://cloud.githubusercontent.com/assets/509309/26072777/1129bd26-396a-11e7-9539-9ac07828f594.png">

To do: 
- [x] Style tabs to look like tabs
- [x] Add necessary markup to 2nd term page
- [x] Determine if Jekyll needs JS wrapped in the equivalent of a `document.ready` or some other thing